### PR TITLE
add /Library/Ruby/bin to the PATH

### DIFF
--- a/.config/fish/config.fish
+++ b/.config/fish/config.fish
@@ -31,6 +31,7 @@ set -gx LD_LIBRARY_PATH
 _add_to_path $HOME
 _add_to_path /usr/local
 _add_to_path /usr/local/share/npm
+_add_to_path /Library/Ruby
 _add_to_path /usr
 _add_to_path /
 


### PR DESCRIPTION
Ruby gems have been moved from /usr/bin to /Library/Ruby/bin on OS X El Capitan, so add that folder to the PATH if needed
